### PR TITLE
chore(monitor): add Agent Monitor summary workflow

### DIFF
--- a/.github/workflows/agent-monitor.yml
+++ b/.github/workflows/agent-monitor.yml
@@ -1,0 +1,66 @@
+name: Agent Monitor
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize Copilot activity and attention items
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            // Gather open PRs by Copilot and RFC-linked PRs
+            const prs = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
+            const now = new Date();
+            const rows = [];
+            for (const pr of prs) {
+              const isCopilot = /copilot/i.test(pr.user?.login || '') || /copilot/i.test(pr.head?.ref || '');
+              const hasRfc = /(RFC[- ]\d{4})/i.test(pr.title + '\n' + (pr.body||''));
+              if (!isCopilot && !hasRfc) continue;
+              const updated = new Date(pr.updated_at);
+              const idleMins = Math.round((now - updated)/60000);
+              rows.push({ number: pr.number, title: pr.title, idleMins, draft: pr.draft, additions: pr.additions, changed: pr.changed_files });
+            }
+            // Check for runs awaiting approval (best-effort via jobs queued by app actor)
+            let approvalsNeeded = 0;
+            try {
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({ owner, repo, per_page: 50 });
+              approvalsNeeded = runs.data.workflow_runs.filter(r => r.status === 'waiting' || r.display_title?.toLowerCase().includes('copilot')).length;
+            } catch {}
+
+            const lines = [];
+            lines.push(`# Agent Monitor`);
+            lines.push(`Updated: ${now.toISOString()}`);
+            lines.push(`\nApprovals needed (approx): ${approvalsNeeded}`);
+            if (rows.length) {
+              lines.push(`\nOpen PRs (Copilot/RFC-linked):`);
+              for (const r of rows) {
+                lines.push(`- PR #${r.number} ${r.draft? '(Draft)': ''}: ${r.title} — idle ${r.idleMins}m, files ${r.changed}, additions ${r.additions}`);
+              }
+            } else {
+              lines.push(`\nNo active Copilot/RFC PRs found.`);
+            }
+            // Upsert pinned issue titled "Agent Monitor"
+            const issues = await github.rest.issues.listForRepo({ owner, repo, state: 'open', labels: 'agent:task' }).catch(()=>({data:[]}));
+            let monitorIssue = null;
+            try {
+              const res = await github.rest.search.issuesAndPullRequests({ q: `repo:${owner}/${repo} is:issue "Agent Monitor" in:title state:open` });
+              monitorIssue = res.data.items[0] || null;
+            } catch {}
+            const body = lines.join('\n');
+            if (!monitorIssue) {
+              const created = await github.rest.issues.create({ owner, repo, title: 'Agent Monitor', body, labels: ['agent:task'] });
+              try { await github.rest.issues.pin({ owner, repo, issue_number: created.data.number }); } catch {}
+            } else {
+              await github.rest.issues.update({ owner, repo, issue_number: monitorIssue.number, body });
+            }


### PR DESCRIPTION
Adds a scheduled and manual Agent Monitor that summarizes Copilot/RFC PRs and approvals needed in a pinned issue.