### PR TITLE
[RFC-0003] Batch 1: pin .NET 9 and enable CPVM

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Terminal.Gui" Version="2.0.5" />
+    <PackageVersion Include="ReactiveUI" Version="19.5.41" />
+    <PackageVersion Include="System.Reactive" Version="6.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+  </ItemGroup>
+</Project>

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -1,0 +1,14 @@
+# Toolchain & CPVM
+
+This repository pins the .NET SDK and manages NuGet package versions centrally.
+
+- .NET SDK is pinned via `global.json` to 9.0.x.
+- Central Package Version Management (CPVM) is enabled via `Directory.Packages.props`.
+
+Packages pinned include:
+- Terminal.Gui v2, ReactiveUI, System.Reactive
+- xUnit, xunit.runner.visualstudio, FluentAssertions
+
+Usage:
+- Install .NET 9 SDK.
+- Restore/build normally; CPVM pins apply across all projects.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
Implements the first minimal batch for RFC-0003:\n- Add global.json pinning .NET 9\n- Add Directory.Packages.props with CPVM pins (Terminal.Gui, ReactiveUI, System.Reactive, xunit, FluentAssertions)\n- Add docs/toolchain.md\n\nCI: no solution yet, so .NET workflow is a no-op.\nNext batch: solution + test project scaffolding.